### PR TITLE
added command in sublime plugin to process bunyad styles

### DIFF
--- a/contribution-docs/sublime-text-3-plugins/Main.sublime-menu
+++ b/contribution-docs/sublime-text-3-plugins/Main.sublime-menu
@@ -51,6 +51,10 @@
 			{
 				"caption" : "Add Annotation Tags (ar)",
 				"command" : "add_annotation_tags_ar"
+			},
+			{
+				"caption" : "Add Bunyad Styles",
+				"command" : "add_bunyad_styles"
 			}
 		]
 	}


### PR DESCRIPTION
Usage:
1. Open document containing bunyad text
2. Get styles for the bunyad text. One per line e.g. If there are 100 lines in document, you need 100 styles.
3. Makhzan -> Add Bunyad Styles
4. Enter styles in the input prompt (An error message will be shown if line counts do not match)
5. The plugin will process the styles and add tags to the document accordingly.
6. For styles that the plugin does not process, a tag of "<UNPROCESSED_{style}>" will be added e.g. if a line has a "Hawashi" style, its corresponding tag will be "<UNPROCESSED_Hawashi>"
